### PR TITLE
Fix issue #30 start/end samples included

### DIFF
--- a/portable_fdsnws_dataselect/miniseed.py
+++ b/portable_fdsnws_dataselect/miniseed.py
@@ -87,7 +87,8 @@ class MSRIDataSegment(ExtractedDataSegment):
         eepoch = self.end_time.timestamp
 
         # Process records that intersect with request time window
-        if msrstart < eepoch and msrend > sepoch:
+        #if msrstart < eepoch and msrend > sepoch:
+        if msrstart <= eepoch and msrend >= sepoch:
 
             # Trim record if coverage and partial overlap with request
             if self.sample_rate > 0 and (msrstart < self.start_time or msrend > self.end_time):
@@ -170,7 +171,6 @@ class MiniseedDataExtractor(object):
         :returns: [(start time, start offset, trim_boolean),
                    (end time, end offset, trim_boolean)]
         """
-        etime = UTCDateTime(NRow.requestend)
         row_stime = UTCDateTime(NRow.starttime)
         row_etime = UTCDateTime(NRow.endtime)
 
@@ -182,7 +182,8 @@ class MiniseedDataExtractor(object):
             if tix[-1][0] == 'latest':
                 tix[-1] = [str(row_etime.timestamp), block_end]
             to_x = [float(x[0]) for x in tix]
-            s_index = bisect.bisect_right(to_x, stime.timestamp) - 1
+            #s_index = bisect.bisect_right(to_x, stime.timestamp) - 1
+            s_index = bisect.bisect_left(to_x, stime.timestamp) - 1
             if s_index < 0:
                 s_index = 0
             e_index = bisect.bisect_right(to_x, etime.timestamp)
@@ -222,6 +223,26 @@ class MiniseedDataExtractor(object):
 
                 starttime = UTCDateTime(NRow.requeststart)
                 endtime = UTCDateTime(NRow.requestend)
+
+                #MTH: requeststart/end is a string - forming UTCDateTime this way is liable
+                #     to round-off.  e.g., seconds = 10.65  gets stored as 10.6499999
+                #     in etime.timestamp and this is compared to the row start/end epochs
+                # This is a hack to fix this, under the assumption that the final fractional
+                #  second (e.g., 1 microsecond) should be 0 and not significant
+
+                secs = int(starttime.timestamp)
+                microsecs = int((starttime.timestamp - secs) * 1e6)
+                if microsecs % 10:
+                    microsecs += 1
+                starttime = UTCDateTime(secs + float(microsecs)/1e6)
+
+                secs = int(endtime.timestamp)
+                microsecs = int((endtime.timestamp - secs) * 1e6)
+                if microsecs % 10:
+                    microsecs += 1
+                endtime = UTCDateTime(secs + float(microsecs)/1e6)
+                #MTH end of changes
+
                 triminfo = self.handle_trimming(starttime, endtime, NRow)
                 total_bytes += triminfo[1][1] - triminfo[0][1]
                 if self.request_limit > 0 and total_bytes > self.request_limit:


### PR DESCRIPTION
Current master:
2022-03-30 15:03:21 - DEBUG - REQUEST: * RW12 * HHN 2022-03-23T00:00:00.000000 2022-03-23T01:00:00.000000
2022-03-30 15:03:21 - ERROR - Code:500 Error:Error -2 in ms_readmsr_r Request:/fdsnws/dataselect/1/query?starttime=2022-03-23T00%3A00%3A00.
000000&endtime=2022-03-23T01%3A00%3A00.000000&network=%2A&station=RW12&location=%2A&channel=HHN

Fix on this branch:
               network: X2
               station: RW12
              location: 00
               channel: HHN
             starttime: 2022-03-23T00:00:00.000000Z
               endtime: 2022-03-23T01:00:00.000000Z
         sampling_rate: 100.0
                 delta: 0.01
                  npts: 360001
                 calib: 1.0
_fdsnws_dataselect_url: http://okesa2.isti.com:9090/fdsnws/dataselect/1/query
               _format: MSEED
                 mseed: AttribDict({'dataquality': 'D', 'number_of_records': 1526, 'encoding': 'STEIM2', 'byteorder': '>', 'record_length': 512, 'filesize': 781312})
            processing: ['ObsPy 1.2.2: trim(endtime=UTCDateTime(2022, 3, 23, 1, 0)::fill_value=None::nearest_sample=True::pad=False::starttime=UTCDateTime(2022, 3, 23, 0, 0))']

Also tested:
 - exact end time
 - return 1 sample (endtime=starttime)